### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # practicepython
 
 exercises solved by me, exercises from http://www.practicepython.org/
+
+To run a selected exercise in an online shell (repl.it), click here and enter the index of any exercise:
+[![Run on Repl.it](https://repl.it/badge/github/cs896afk/practicepython)](https://repl.it/github/cs896afk/practicepython)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ChristophSchwe1/practicepython).